### PR TITLE
Add ignored_exceptions config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ For example, the module can be loaded only for the admin users or only for dev&p
     'visibility_service_name' => Application\Service\VisibilityService::class,
     ```
 
+### Ignored Exceptions
+
+By default, this module will route all exceptions to Whoops; however, you can create a list of
+exception classes that will be ignored by Whoops.
+
+##### Usage:
+Set the `ignored_exceptions` configuration to an array of class names:
+```php
+'ignored_exceptions' => [My\Exception::class, My\OtherException::class]
+```
+
 
 # License
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -31,6 +31,8 @@ class Module implements ConfigProviderInterface, BootstrapListenerInterface {
     protected $template = 'laminas_whoops/simple_error';
     /** @var Run */
     protected $whoops;
+    /** @var string[] */
+    protected $ignoredExceptions = [];
 
     /**
      * Return default laminas-serializer configuration for laminas-mvc applications.
@@ -89,6 +91,9 @@ class Module implements ConfigProviderInterface, BootstrapListenerInterface {
             }
         }
 
+        if (isset($config['ignored_exceptions'])) {
+            $this->ignoredExceptions = (array)$config['ignored_exceptions'];
+        }
         if (isset($config['template_render'])) {
             $this->setTemplate($config['template_render']);
         }
@@ -131,6 +136,10 @@ class Module implements ConfigProviderInterface, BootstrapListenerInterface {
 
             case Application::ERROR_EXCEPTION:
             default:
+                // Bail out if we're explicitly told to ignore this exception:
+                if (in_array(get_class($e->getParam('exception')), $this->ignoredExceptions)) {
+                    return;
+                }
                 // Set writeToOutput to false for rendered output with laminas-view
                 $this->whoops->writeToOutput(false);
                 $result = $this->whoops->handleException($e->getParam('exception'));


### PR DESCRIPTION
I migrated to laminas-whoops from https://github.com/ghislainf/zf2-whoops, which included a useful `whoops_no_catch` configuration option that laminas-whoops does not currently support. This PR adds equivalent (though differently-named) functionality to laminas-whoops.

I am happy to expand upon documentation or examples if that would be helpful -- this is just an initial MVP to see whether there is interest in adding the feature. Please let me know if you need me to make any revisions!