### PR TITLE
Fix PHP 8.4 deprecation

### DIFF
--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -28,7 +28,7 @@ class Factory implements FactoryInterface  {
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null) {
         $config = $container->has('config') ? $container->get('config') : [];
-        $config = isset($config['whoops']) ? $config['whoops'] : [];
+        $config = $config['whoops'] ?? [];
 
         return new $requestedName($container, $config);
     }

--- a/src/Factory/Factory.php
+++ b/src/Factory/Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Created by PhpStorm.
  * User: Ppito
@@ -13,20 +14,21 @@
 namespace WhoopsErrorHandler\Factory;
 
 use Interop\Container\ContainerInterface;
-use WhoopsErrorHandler\Handler\HandlerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use WhoopsErrorHandler\Handler\HandlerInterface;
 
-class Factory implements FactoryInterface  {
-
+class Factory implements FactoryInterface
+{
     /**
      * Invoke Handler
      *
      * @param ContainerInterface $container
-     * @param string             $requestedName
-     * @param array|null         $options
+     * @param string $requestedName
+     * @param array|null $options
      * @return HandlerInterface
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) {
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = $config['whoops'] ?? [];
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -75,7 +75,7 @@ class Module implements ConfigProviderInterface, BootstrapListenerInterface {
      */
     protected function configureService(ContainerInterface $container) {
         $config = $container->has('config') ? $container->get('config') : [];
-        $config = isset($config['whoops']) ? $config['whoops'] : [];
+        $config = $config['whoops'] ?? [];
 
         $serviceName = array_key_exists('visibility_service_name', $config) && !empty($config['visibility_service_name']) ?
             $config['visibility_service_name'] :


### PR DESCRIPTION
Fixes `Deprecated: WhoopsErrorHandler\Factory\Factory::__invoke(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead in /var/www/app/vendor/ppito/laminas-whoops/src/Factory/Factory.php on line 29`