### PR TITLE
Fix whoops variable not initialized

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -30,8 +30,8 @@ class Module implements ConfigProviderInterface, BootstrapListenerInterface {
 
     /** @var string */
     protected string $template = 'laminas_whoops/simple_error';
-    /** @var Run */
-    protected ?Run $whoops;
+    /** @var Run|null */
+    protected ?Run $whoops = null;
     /** @var string[] */
     protected array $ignoredExceptions = [];
 


### PR DESCRIPTION
I ran into an issue using a CLI tool based on Symfony console that failed on line 59 in Module.php because $whoops wasn't initialized.

This fixed the problem.